### PR TITLE
Feat: Allow creating multiple workouts at once

### DIFF
--- a/justfile
+++ b/justfile
@@ -42,7 +42,7 @@ setup:
 
 # Run all tests
 test *extra_args:
-    pytest -n 2 --cov --random-order {{ extra_args }}
+    pytest -n 4 --cov --random-order {{ extra_args }}
 
 # Run tests and publish coverage report
 publish-test-report:

--- a/src/swole_v2/database/repositories/base.py
+++ b/src/swole_v2/database/repositories/base.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import json
+from typing import Any
+
 from edgedb import AsyncIOClient
 from fastapi import Depends
 
@@ -13,3 +16,9 @@ class BaseRepository:
     @classmethod
     async def as_dependency(cls, client: AsyncIOClient = Depends(get_async_client)) -> "BaseRepository":
         return cls(client)
+
+    async def query_json(self, query: str, *args: Any, **kwargs: Any) -> list[dict[str, Any]]:
+        async for transaction in self.client.transaction():
+            async with transaction:
+                result = await transaction.query_json(query, *args, **kwargs)
+        return json.loads(result)

--- a/src/swole_v2/routers/workouts.py
+++ b/src/swole_v2/routers/workouts.py
@@ -38,11 +38,11 @@ async def detail(
 
 @router.post("/create", response_model=SuccessResponse)
 async def create(
-    data: WorkoutCreate,
+    data: list[WorkoutCreate],
     current_user: User = Depends(get_current_active_user),
     respository: WorkoutRepository = Depends(WorkoutRepository.as_dependency),
 ) -> SuccessResponse:
-    return SuccessResponse(results=[await respository.create(current_user.id, data)])
+    return SuccessResponse(results=await respository.create(current_user.id, data))
 
 
 @router.post("/delete", response_model=SuccessResponse)


### PR DESCRIPTION
- Allows the creation of multiple workouts at once
- Uses transactions to ensure failures do not get added to the database
- Adds tests for the new functionality
- Increases the pytest workers from 2 to 4 