### PR TITLE
Feat: Allow adding multiple exercises to workout at once

### DIFF
--- a/src/swole_v2/routers/workouts.py
+++ b/src/swole_v2/routers/workouts.py
@@ -64,13 +64,13 @@ async def update(
     return SuccessResponse(results=[await respository.update(current_user.id, data)])
 
 
-@router.post("/add-exercise", response_model=SuccessResponse)
-async def add_exercise(
-    data: WorkoutAddExercise,
+@router.post("/add-exercises", response_model=SuccessResponse)
+async def add_exercises(
+    data: list[WorkoutAddExercise],
     current_user: User = Depends(get_current_active_user),
     respository: WorkoutRepository = Depends(WorkoutRepository.as_dependency),
 ) -> SuccessResponse:
-    return SuccessResponse(results=[await respository.add_exercise(current_user.id, data)])
+    return SuccessResponse(results=await respository.add_exercises(current_user.id, data))
 
 
 @router.post("/exercises", response_model=SuccessResponse)


### PR DESCRIPTION
## Summary

The `/add-exercises` endpoint can now be passed a list of dictionaries containing the `workout_id` of the workout you want to add the exercise to, and the `exercise_id` of the exercise you want to add to the workout.

If no workout can be found for the given workout id, the result will be an empty list. If **ANY** exercise cannot be found, the endpoint will raise a "No exercise found" error, and no changes will be added to the database.