### PR TITLE
Feat: Allow users to get detail of multiple workouts at once

### DIFF
--- a/src/swole_v2/errors/handlers.py
+++ b/src/swole_v2/errors/handlers.py
@@ -30,7 +30,7 @@ def business_error_handler(_: Request, exception: BusinessError) -> JSONResponse
 
 def request_validation_error_handler(_: Request, exception: RequestValidationError) -> JSONResponse:
     error = exception.errors()[0]
-    message = f"{error['msg'].title()} ({error['loc'][1]})."
+    message = f"{error['msg'].title()}. Hint: {error['loc']}.".replace("'", "").replace(",", " >")
     return JSONResponse(
         status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
         content=ErrorResponse(message=message).dict(),  # Only dsiplays the first error

--- a/src/swole_v2/routers/workouts.py
+++ b/src/swole_v2/routers/workouts.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Query
 
 from ..database.repositories import WorkoutRepository
 from ..dependencies.auth import get_current_active_user
@@ -12,28 +14,20 @@ from ..schemas import (
     WorkoutCreate,
     WorkoutDelete,
     WorkoutDetail,
-    WorkoutGetAllExercises,
     WorkoutUpdate,
 )
 
 router = APIRouter(prefix="/workouts", tags=["workouts"])
 
 
-@router.post("/all", response_model=SuccessResponse)
-async def get_all(
-    current_user: User = Depends(get_current_active_user),
-    respository: WorkoutRepository = Depends(WorkoutRepository.as_dependency),
-) -> SuccessResponse:
-    return SuccessResponse(results=await respository.get_all(current_user.id))
-
-
 @router.post("/detail", response_model=SuccessResponse)
 async def detail(
-    data: WorkoutDetail,
+    data: list[WorkoutDetail],
     current_user: User = Depends(get_current_active_user),
     respository: WorkoutRepository = Depends(WorkoutRepository.as_dependency),
+    with_exercises: Annotated[bool, Query()] = False,
 ) -> SuccessResponse:
-    return SuccessResponse(results=[await respository.detail(current_user.id, data.workout_id)])
+    return SuccessResponse(results=await respository.detail(current_user.id, data, with_exercises))
 
 
 @router.post("/create", response_model=SuccessResponse)
@@ -71,15 +65,6 @@ async def add_exercises(
     respository: WorkoutRepository = Depends(WorkoutRepository.as_dependency),
 ) -> SuccessResponse:
     return SuccessResponse(results=await respository.add_exercises(current_user.id, data))
-
-
-@router.post("/exercises", response_model=SuccessResponse)
-async def get_all_exercises(
-    data: WorkoutGetAllExercises,
-    current_user: User = Depends(get_current_active_user),
-    respository: WorkoutRepository = Depends(WorkoutRepository.as_dependency),
-) -> SuccessResponse:
-    return SuccessResponse(results=await respository.get_all_exercises(current_user.id, data))
 
 
 @router.post("/copy", response_model=SuccessResponse)

--- a/src/swole_v2/schemas/__init__.py
+++ b/src/swole_v2/schemas/__init__.py
@@ -8,7 +8,6 @@ from .workouts import (
     WorkoutCreate,
     WorkoutDelete,
     WorkoutDetail,
-    WorkoutGetAllExercises,
     WorkoutUpdate,
 )
 
@@ -24,7 +23,6 @@ __all__ = [
     "WorkoutDetail",
     "WorkoutDelete",
     "WorkoutAddExercise",
-    "WorkoutGetAllExercises",
     "SuccessResponse",
     "ErrorResponse",
     "SetGetAll",

--- a/src/swole_v2/schemas/workouts.py
+++ b/src/swole_v2/schemas/workouts.py
@@ -45,12 +45,6 @@ class WorkoutAddExercise(BaseModel):
     _check_id = schema_validator("workout_id", "exercise_id")(check_is_uuid)
 
 
-class WorkoutGetAllExercises(BaseModel):
-    workout_id: UUID
-
-    _check_id = schema_validator("workout_id")(check_is_uuid)
-
-
 class WorkoutCopy(BaseModel):
     workout_id: UUID
     date: datetime.date

--- a/tests/api_tests/test_users.py
+++ b/tests/api_tests/test_users.py
@@ -38,9 +38,13 @@ class TestUsers(APITestBase):
     @pytest.mark.parametrize(
         "data, message",
         [
-            pytest.param({"password": fake.word()}, "Field Required (username).", id="Missing username fails"),
-            pytest.param({"username": fake.word()}, "Field Required (password).", id="Missing password fails"),
-            pytest.param({}, "Field Required (username).", id="Empty json fails"),
+            pytest.param(
+                {"password": fake.word()}, "Field Required. Hint: (body > username).", id="Missing username fails"
+            ),
+            pytest.param(
+                {"username": fake.word()}, "Field Required. Hint: (body > password).", id="Missing password fails"
+            ),
+            pytest.param({}, "Field Required. Hint: (body > username).", id="Empty json fails"),
         ],
     )
     async def test_login_with_missing_json_fields_fails(self, data: dict[str, Any], message: str) -> None:

--- a/tests/api_tests/test_workouts.py
+++ b/tests/api_tests/test_workouts.py
@@ -29,26 +29,67 @@ class TestWorkouts(APITestBase):
         ],
     )
 
-    async def test_workout_get_all(self) -> None:
-        workouts = await self.sample.workouts()
-        response = await self._post_success("/all")
-
-        assert response.results
-        assert len(response.results) == len(workouts)
-
     async def test_workout_detail_succeeds(self) -> None:
         workout = await self.sample.workout()
 
-        response = await self._post_success("/detail", data={"workout_id": str(workout.id)})
+        response = await self._post_success("/detail", data=[{"workout_id": str(workout.id)}])
 
         assert response.results
         assert response.results == [
             {"id": str(workout.id), "name": workout.name, "date": workout.date.strftime("%Y-%m-%d")}
         ]
 
+    async def test_workout_detail_succeeds_with_multiple_workouts(self) -> None:
+        workout_1 = await self.sample.workout()
+        workout_2 = await self.sample.workout()
+        data = [
+            {"workout_id": str(workout_1.id)},
+            {"workout_id": str(workout_2.id)},
+        ]
+
+        response = await self._post_success("/detail", data=data)
+
+        assert response.results
+        assert len(response.results) == 2
+
+    async def test_workout_detail_succeeds_with_query_parameter(self) -> None:
+        workout_with_exercises = await self.sample.workout(exercises=await self.sample.exercises())
+        workout_without_exercises = await self.sample.workout()
+        data = [
+            {"workout_id": str(workout_with_exercises.id)},
+            {"workout_id": str(workout_without_exercises.id)},
+        ]
+
+        response = await self._post_success("/detail?with_exercises=true", data=data)
+        expected_results = [
+            {
+                "id": str(workout_with_exercises.id),
+                "name": workout_with_exercises.name,
+                "date": workout_with_exercises.date.strftime("%Y-%m-%d"),
+                "exercises": [
+                    {"id": str(e.id), "name": e.name, "notes": e.notes} for e in workout_with_exercises.exercises
+                ],
+            },
+            {
+                "id": str(workout_without_exercises.id),
+                "name": workout_without_exercises.name,
+                "date": workout_without_exercises.date.strftime("%Y-%m-%d"),
+                "exercises": [],
+            },
+        ]
+
+        assert response.results
+        assert all(results in response.results for results in expected_results)
+
     @pytest.mark.parametrize(*invalid_workout_id_params)
     async def test_workout_detail_fails_with_invalid_workout_id(self, workout_id: Any, message: str) -> None:
-        response = await self._post_error("/detail", data={"workout_id": str(workout_id)})
+        valid_workout = await self.sample.workout()
+        data = [
+            {"workout_id": str(valid_workout.id)},
+            {"workout_id": str(workout_id)},
+        ]
+
+        response = await self._post_error("/detail", data=data)
 
         assert response.message == message
 
@@ -399,30 +440,6 @@ class TestWorkouts(APITestBase):
         response = await self._post_error("/add-exercises", data=[data])
 
         assert response.message == INVALID_ID
-
-    @pytest.mark.parametrize(
-        "no_exercises",
-        [
-            pytest.param(True, id="Test get all exercises returns empty list when workout has no exercises"),
-            pytest.param(False, id="Test get all exercises returns all exercises belonging to workout"),
-        ],
-    )
-    async def test_get_all_exercises_succeeds(self, no_exercises: bool) -> None:
-        exercises = await self.sample.exercises(size=10)
-        # add half of the exercises since the result should only return those owned by the workout
-        workout = await self.sample.workout(exercises=[] if no_exercises else exercises[:5])
-
-        response = await self._post_success("/exercises", data={"workout_id": str(workout.id)})
-
-        if no_exercises:
-            assert response.results == []
-        assert response.results == [{"id": str(e.id), "name": e.name, "notes": e.notes} for e in workout.exercises]
-
-    @pytest.mark.parametrize(*invalid_workout_id_params)
-    async def test_get_all_exercises_fails(self, workout_id: Any, message: str) -> None:
-        response = await self._post_error("/exercises", data={"workout_id": str(workout_id)})
-
-        assert response.message == message
 
     async def test_workout_copy_succeeds(self) -> None:
         exercises = await self.sample.exercises()


### PR DESCRIPTION
- Allows users to get the details of multiple workouts at once
- Adds an optional query parameter to the `workouts/detail` endpoint that specifies whether to load the workouts' exercises or not
- Changes the error handler message to fix problem with index being out of range