### PR TITLE
:bug: fix: use personal access token with github actions

### DIFF
--- a/.github/workflows/pre-commit-sync-update.yml
+++ b/.github/workflows/pre-commit-sync-update.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.PAT }}
 
       - name: Set up Python
         uses: actions/setup-python@v4


### PR DESCRIPTION
A push from an action doesn't trigger subsequent actions (see [discussion](https://github.com/orgs/community/discussions/25702#discussioncomment-3248823)) 

Use a personal access token (PAT) to perform push in action. 