### PR TITLE
Fix renovate action

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -17,7 +17,6 @@ jobs:
       - name: Run Renovate Bot
         uses: renovatebot/github-action@v40.0.2
         with:
-          renovate-version: 35.0.0
           configurationFile: ./renovate-config.js
           token: ${{ secrets.RENOVATE_TOKEN }}
         env:


### PR DESCRIPTION
Using a [new renovate action](https://github.com/renovatebot/github-action?tab=readme-ov-file) has broken the action. Looks like it's because the version tag can't be found 🤔 