### PR TITLE
Squash Renovatebot PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,7 @@
     "packageRules": [
         {
             "automerge": true,
+            "automergeStrategy": "squash",
             "matchUpdateTypes": [
                 "minor",
                 "patch",


### PR DESCRIPTION
Renovatebot is not squashing PRs when automerging. This changes that.

<img width="477" alt="Screenshot 2024-04-25 at 9 47 10" src="https://github.com/te25son/Swole-V2/assets/39095798/919be5b7-03d6-4bc5-9233-c90a4dfb3e19">
